### PR TITLE
Handle fixed length option correctly in Options.Marshal

### DIFF
--- a/options.go
+++ b/options.go
@@ -125,19 +125,19 @@ func (o *Options) Unmarshal(buf *uio.Lexer) error {
 func (o Options) Marshal(b *uio.Lexer) {
 	for _, c := range o.sortedKeys() {
 		code := OptionCode(c)
-		data := o[code]
+		// Some DHCPv4 options have fixed length and do not put
+		// length on the wire.
+		if code == End || code == Pad {
+			b.Write8(uint8(code))
+			continue
+		}
 
 		// RFC 3396: If more than 256 bytes of data are given, the
 		// option is simply listed multiple times.
+		data := o[code]
 		for len(data) > 0 {
 			// 1 byte: option code
 			b.Write8(uint8(code))
-
-			// Some DHCPv4 options have fixed length and do not put
-			// length on the wire.
-			if code == End || code == Pad {
-				continue
-			}
 
 			n := len(data)
 			if n > math.MaxUint8 {

--- a/options_test.go
+++ b/options_test.go
@@ -34,6 +34,34 @@ func TestOptionsMarshal(t *testing.T) {
 			},
 		},
 		{
+			opts: Options{
+				0: []byte{},
+			},
+			want: []byte{0, 255},
+		},
+		{
+			opts: Options{
+				255: []byte{},
+			},
+			want: []byte{255},
+		},
+		{
+			opts: Options{
+				255: []byte{1, 2, 3, 4},
+			},
+			want: []byte{255},
+		},
+		{
+			opts: Options{
+				5:   []byte{3, 2, 1},
+				255: []byte{},
+			},
+			want: []byte{
+				5, 3, 3, 2, 1,
+				255,
+			},
+		},
+		{
 			// Test sorted key order.
 			opts: Options{
 				5:   []byte{1, 2, 3},


### PR DESCRIPTION
Without this fix, specifiying and End (255) or Pad (0) option without
any data would not marshal the option. If any data was given (by
mistake), the Marshal func would be caught in an endless loop.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>